### PR TITLE
Changed selector to include Black Cards

### DIFF
--- a/codenamesSearch.user.js
+++ b/codenamesSearch.user.js
@@ -15,7 +15,7 @@
 
     const attachSearchButtons = () => {
         // Find all tiles
-        const tiles = document.querySelectorAll('.card.shadow-card.text-black');
+        const tiles = document.querySelectorAll('.card.shadow-card');
 
         tiles.forEach(tile => {
             // Avoid duplicates


### PR DESCRIPTION
As the Spymaster, cards have a "card.shadow-card.white-text" selector rather than "card.shadow-card.black-text" selector, so by changing query to just ".card.shadow-card" you include the black card.